### PR TITLE
Add error macro

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,14 @@ export function $print(...params: unknown[]): void;
  */
 export function $warn(...params: unknown[]): void;
 
+/**
+ * Same as `error`, but includes the source information
+ * Will be prefixed with something like `[src/shared/module.ts:11]`
+ *
+ * This can be optionally enabled/disabled in emit using `enabled` and `environmentRequires`.
+ */
+export function $error(message: string, level: number): void;
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 /**

--- a/src/transform/macros/call/index.ts
+++ b/src/transform/macros/call/index.ts
@@ -2,7 +2,7 @@ import { CallMacro } from "../macro";
 import { CompileTimeMacro } from "./compileTime";
 import { DebugMacro } from "./dbg";
 import { GitMacro } from "./git";
-import { PrintMacro, WarnMacro } from "./logging";
+import { ErrorMacro, PrintMacro, WarnMacro } from "./logging";
 import { NameOfMacro } from "./nameof";
 
 export const CALL_MACROS = new Array<CallMacro>(
@@ -11,5 +11,6 @@ export const CALL_MACROS = new Array<CallMacro>(
 	CompileTimeMacro,
 	PrintMacro,
 	WarnMacro,
+	ErrorMacro,
 	NameOfMacro,
 );

--- a/src/transform/macros/call/logging.ts
+++ b/src/transform/macros/call/logging.ts
@@ -1,6 +1,6 @@
 import ts, { factory } from "typescript";
 import { TransformState } from "../../../class/transformState";
-import { createDebugPrefixLiteral } from "../../../util/shared";
+import { createDebugPrefixLiteral, createErrorPrefixLiteral } from "../../../util/shared";
 import { CallMacro } from "../macro";
 
 export const PrintMacro: CallMacro = {
@@ -23,6 +23,18 @@ export const WarnMacro: CallMacro = {
 		return factory.updateCallExpression(node, factory.createIdentifier("warn"), undefined, [
 			createDebugPrefixLiteral(node),
 			...node.arguments,
+		]);
+	},
+};
+
+export const ErrorMacro: CallMacro = {
+	getSymbol(state: TransformState) {
+		return state.symbolProvider.moduleFile!.get("$error");
+	},
+	transform(state: TransformState, node: ts.CallExpression) {
+		return factory.updateCallExpression(node, factory.createIdentifier("error"), undefined, [
+			createErrorPrefixLiteral(node),
+			...node.arguments.slice(1),
 		]);
 	},
 };

--- a/src/util/shared.ts
+++ b/src/util/shared.ts
@@ -91,3 +91,14 @@ export function createDebugPrefixLiteral(node: ts.Node): ts.StringLiteral {
 	const relativePath = path.relative(process.cwd(), node.getSourceFile().fileName).replace(/\\/g, "/");
 	return factory.createStringLiteral(`[${relativePath}:${linePos.line + 1}]`, true);
 }
+
+export function createErrorPrefixLiteral(node: ts.CallExpression): ts.BinaryExpression {
+	const sourceFile = node.getSourceFile();
+	const linePos = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+	const relativePath = path.relative(process.cwd(), node.getSourceFile().fileName).replace(/\\/g, "/");
+	return factory.createBinaryExpression(
+		factory.createStringLiteral(`[${relativePath}:${linePos.line + 1}]`, true),
+		factory.createToken(ts.SyntaxKind.PlusToken),
+		node.arguments[0],
+	);
+}


### PR DESCRIPTION
Adds a `$error` macro.
As per the docs the first arg is a string, not unknown