### PR TITLE
Only include required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.2.0",
   "description": "Transformer for debugging things in roblox-ts",
   "main": "out/index.js",
+  "files": [
+    "out",
+    "index.d.ts"
+  ],
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build"


### PR DESCRIPTION
Sets the `files` property in `package.json` to only include the `out` directory and `index.d.ts`

For context, serving the `test` workspace in [Centurion](https://github.com/paradoxuum/centurion)'s repository will cause an error, because it includes `example/default.project.json` from the `core` workspace's node_modules. To my knowledge, it's not currently possible to ignore this directory due to a Rojo bug preventing paths above the current directory from being ignored.